### PR TITLE
feat: add clean command to remove invalid worktrees from state

### DIFF
--- a/src/commands/clean.rs
+++ b/src/commands/clean.rs
@@ -1,0 +1,55 @@
+use anyhow::Result;
+use colored::Colorize;
+
+use crate::git::list_worktrees;
+use crate::state::XlaudeState;
+
+pub fn handle_clean() -> Result<()> {
+    let mut state = XlaudeState::load()?;
+
+    if state.worktrees.is_empty() {
+        println!("{} No worktrees in state", "✨".green());
+        return Ok(());
+    }
+
+    println!("{} Checking for invalid worktrees...", "🔍".cyan());
+
+    // Get list of actual worktrees from git
+    let actual_worktrees = list_worktrees()?;
+
+    // Find worktrees in state that no longer exist
+    let mut removed_count = 0;
+    let mut worktrees_to_remove = Vec::new();
+
+    for (name, info) in &state.worktrees {
+        if !actual_worktrees.contains(&info.path) {
+            println!(
+                "  {} Found invalid worktree: {} ({})",
+                "❌".red(),
+                name.yellow(),
+                info.path.display()
+            );
+            worktrees_to_remove.push(name.clone());
+            removed_count += 1;
+        }
+    }
+
+    // Remove invalid worktrees from state
+    for name in worktrees_to_remove {
+        state.worktrees.remove(&name);
+    }
+
+    if removed_count > 0 {
+        state.save()?;
+        println!(
+            "{} Removed {} invalid worktree{}",
+            "✅".green(),
+            removed_count,
+            if removed_count == 1 { "" } else { "s" }
+        );
+    } else {
+        println!("{} All worktrees are valid", "✨".green());
+    }
+
+    Ok(())
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,10 +1,12 @@
 pub mod add;
+pub mod clean;
 pub mod create;
 pub mod delete;
 pub mod list;
 pub mod open;
 
 pub use add::handle_add;
+pub use clean::handle_clean;
 pub use create::handle_create;
 pub use delete::handle_delete;
 pub use list::handle_list;

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 pub fn execute_git(args: &[&str]) -> Result<String> {
@@ -59,4 +59,17 @@ pub fn is_in_worktree() -> Result<bool> {
         }
         Err(_) => Ok(false),
     }
+}
+
+pub fn list_worktrees() -> Result<Vec<PathBuf>> {
+    let output = execute_git(&["worktree", "list", "--porcelain"])?;
+    let mut worktrees = Vec::new();
+
+    for line in output.lines() {
+        if let Some(path) = line.strip_prefix("worktree ") {
+            worktrees.push(PathBuf::from(path));
+        }
+    }
+
+    Ok(worktrees)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ mod git;
 mod state;
 mod utils;
 
-use commands::{handle_add, handle_create, handle_delete, handle_list, handle_open};
+use commands::{handle_add, handle_clean, handle_create, handle_delete, handle_list, handle_open};
 
 #[derive(Parser)]
 #[command(name = "xlaude")]
@@ -41,6 +41,8 @@ enum Commands {
     },
     /// List all active Claude instances
     List,
+    /// Clean up invalid worktrees from state
+    Clean,
 }
 
 fn main() -> Result<()> {
@@ -52,5 +54,6 @@ fn main() -> Result<()> {
         Commands::Delete { name } => handle_delete(name),
         Commands::Add { name } => handle_add(name),
         Commands::List => handle_list(),
+        Commands::Clean => handle_clean(),
     }
 }


### PR DESCRIPTION
## Summary

close #4 

- Add `xlaude clean` command that checks for and removes invalid worktrees
- Implement list_worktrees() function in git module to get actual git worktrees
- Compare state.json entries against actual worktrees and remove invalid ones
- Provide clear feedback showing which worktrees were removed

## Preview

<img width="1008" height="567" alt="image" src="https://github.com/user-attachments/assets/0880c744-bdd5-41c0-bf74-5f49974f4a77" />
