### PR TITLE
feat: Add rename command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,13 @@ xlaude 是一个用于管理 Claude 实例的命令行工具，通过 git worktr
 - 适用于使用 `git worktree remove` 后的清理
 - 保持 xlaude 状态与 git 状态同步
 
+### xlaude rename <old_name> <new_name>
+重命名 worktree 状态：
+- 重命名 xlaude 管理中的 worktree 名称
+- 仅更新 xlaude 状态，不影响实际的 git worktree 或目录
+- 检查新名称是否已存在，避免冲突
+- 保留所有 Claude sessions 和元数据
+
 ## 技术实现
 
 - 使用 Rust 开发
@@ -99,6 +106,9 @@ xlaude delete feature-x
 
 # 清理无效的 worktree
 xlaude clean
+
+# 重命名 worktree
+xlaude rename feature-x feature-improved
 
 # 典型工作流
 xlaude create my-feature  # 创建 worktree

--- a/README.md
+++ b/README.md
@@ -98,10 +98,15 @@ Performs safety checks for:
 xlaude clean
 ```
 
-Removes worktrees from xlaude's state that no longer exist in git. This is useful when:
-- You've used `git worktree remove` directly
-- Worktree directories were manually deleted
-- Maintaining consistency between git and xlaude state
+Removes worktrees from state management that have been manually deleted using `git worktree remove`.
+
+### Rename a worktree
+
+```bash
+xlaude rename <old_name> <new_name>
+```
+
+Renames a worktree in xlaude management. This only updates the xlaude state and doesn't affect the actual git worktree or directory.
 
 ## Typical Workflow
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -4,6 +4,7 @@ pub mod create;
 pub mod delete;
 pub mod list;
 pub mod open;
+pub mod rename;
 
 pub use add::handle_add;
 pub use clean::handle_clean;
@@ -11,3 +12,4 @@ pub use create::handle_create;
 pub use delete::handle_delete;
 pub use list::handle_list;
 pub use open::handle_open;
+pub use rename::handle_rename;

--- a/src/commands/rename.rs
+++ b/src/commands/rename.rs
@@ -1,0 +1,48 @@
+use anyhow::{Context, Result, bail};
+use colored::Colorize;
+
+use crate::git;
+use crate::state::XlaudeState;
+
+pub fn handle_rename(old_name: String, new_name: String) -> Result<()> {
+    let repo = git::get_repo_name()?;
+    let mut state = XlaudeState::load()?;
+
+    let old_key = XlaudeState::make_key(&repo, &old_name);
+    let new_key = XlaudeState::make_key(&repo, &new_name);
+
+    if !state.worktrees.contains_key(&old_key) {
+        bail!("Worktree '{}' not found in repository '{}'", old_name, repo);
+    }
+
+    if state.worktrees.contains_key(&new_key) {
+        bail!(
+            "Worktree '{}' already exists in repository '{}'",
+            new_name,
+            repo
+        );
+    }
+
+    let mut worktree_data = state
+        .worktrees
+        .remove(&old_key)
+        .context("Failed to get worktree data")?;
+
+    // Update the name field in the worktree info
+    worktree_data.name = new_name.clone();
+
+    state.worktrees.insert(new_key, worktree_data);
+    state.save()?;
+
+    println!(
+        "{} {} {} {} {} {}",
+        "✓".green(),
+        "Renamed worktree".green(),
+        old_name.cyan(),
+        "to".green(),
+        new_name.cyan(),
+        format!("in repository '{}'", repo).dimmed()
+    );
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,9 @@ mod git;
 mod state;
 mod utils;
 
-use commands::{handle_add, handle_clean, handle_create, handle_delete, handle_list, handle_open};
+use commands::{
+    handle_add, handle_clean, handle_create, handle_delete, handle_list, handle_open, handle_rename,
+};
 
 #[derive(Parser)]
 #[command(name = "xlaude")]
@@ -39,6 +41,13 @@ enum Commands {
         /// Name for the worktree (defaults to current branch name)
         name: Option<String>,
     },
+    /// Rename a worktree
+    Rename {
+        /// Current name of the worktree
+        old_name: String,
+        /// New name for the worktree
+        new_name: String,
+    },
     /// List all active Claude instances
     List,
     /// Clean up invalid worktrees from state
@@ -53,6 +62,7 @@ fn main() -> Result<()> {
         Commands::Open { name } => handle_open(name),
         Commands::Delete { name } => handle_delete(name),
         Commands::Add { name } => handle_add(name),
+        Commands::Rename { old_name, new_name } => handle_rename(old_name, new_name),
         Commands::List => handle_list(),
         Commands::Clean => handle_clean(),
     }


### PR DESCRIPTION
## Summary

Adds `xlaude rename <old_name> <new_name>` to rename worktrees in xlaude's state.

## Why?

Sometimes I realize I gave a worktree a bad name and want to change it. Currently have to delete and recreate, losing Claude sessions.

## What it does

- Renames the worktree in xlaude's tracking (not the actual directory)
- Keeps all metadata like creation time and Claude sessions
- Simple and safe - doesn't touch git or filesystem

## Example

```bash
xlaude rename feature-x better-name
```

<img width="617" height="46" alt="image" src="https://github.com/user-attachments/assets/1d7a4b18-4bac-43e1-b707-7a89022ce11c" />
