### PR TITLE
fix: sanitize branch names with slashes for worktree directories

### DIFF
--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -4,6 +4,7 @@ use colored::Colorize;
 
 use crate::git::{get_current_branch, get_repo_name, is_in_worktree};
 use crate::state::{WorktreeInfo, XlaudeState};
+use crate::utils::sanitize_branch_name;
 
 pub fn handle_add(name: Option<String>) -> Result<()> {
     // Check if we're in a git repository
@@ -17,8 +18,11 @@ pub fn handle_add(name: Option<String>) -> Result<()> {
     // Get current branch name
     let current_branch = get_current_branch()?;
 
-    // Use provided name or default to branch name
-    let worktree_name = name.unwrap_or_else(|| current_branch.clone());
+    // Use provided name or default to sanitized branch name
+    let worktree_name = match name {
+        Some(n) => n,
+        None => sanitize_branch_name(&current_branch),
+    };
 
     // Get current directory
     let current_dir = std::env::current_dir()?;

--- a/src/commands/open.rs
+++ b/src/commands/open.rs
@@ -6,6 +6,7 @@ use std::process::Command;
 
 use crate::git::{get_current_branch, get_repo_name, is_base_branch, is_in_worktree};
 use crate::state::{WorktreeInfo, XlaudeState};
+use crate::utils::sanitize_branch_name;
 
 pub fn handle_open(name: Option<String>) -> Result<()> {
     let mut state = XlaudeState::load()?;
@@ -18,8 +19,11 @@ pub fn handle_open(name: Option<String>) -> Result<()> {
         let current_branch = get_current_branch()?;
         let current_dir = std::env::current_dir()?;
 
+        // Sanitize branch name for key lookup
+        let worktree_name = sanitize_branch_name(&current_branch);
+
         // Check if this worktree is already managed
-        let key = XlaudeState::make_key(&repo_name, &current_branch);
+        let key = XlaudeState::make_key(&repo_name, &worktree_name);
 
         if state.worktrees.contains_key(&key) {
             // Already managed, open directly
@@ -27,7 +31,7 @@ pub fn handle_open(name: Option<String>) -> Result<()> {
                 "{} Opening current worktree '{}/{}'...",
                 "🚀".green(),
                 repo_name,
-                current_branch.cyan()
+                worktree_name.cyan()
             );
         } else {
             // Not managed, ask if user wants to add it
@@ -61,13 +65,13 @@ pub fn handle_open(name: Option<String>) -> Result<()> {
             println!(
                 "{} Adding worktree '{}' to xlaude management...",
                 "➕".green(),
-                current_branch.cyan()
+                worktree_name.cyan()
             );
 
             state.worktrees.insert(
                 key.clone(),
                 WorktreeInfo {
-                    name: current_branch.clone(),
+                    name: worktree_name.clone(),
                     branch: current_branch.clone(),
                     path: current_dir.clone(),
                     repo_name: repo_name.clone(),
@@ -81,7 +85,7 @@ pub fn handle_open(name: Option<String>) -> Result<()> {
                 "{} Opening worktree '{}/{}'...",
                 "🚀".green(),
                 repo_name,
-                current_branch.cyan()
+                worktree_name.cyan()
             );
         }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -33,6 +33,12 @@ pub fn generate_random_name() -> Result<String> {
         .context("Failed to generate random name")
 }
 
+/// Sanitize a branch name for use in directory names
+/// Replaces forward slashes with hyphens to avoid creating subdirectories
+pub fn sanitize_branch_name(branch: &str) -> String {
+    branch.replace('/', "-")
+}
+
 pub fn execute_in_dir<P, F, R>(path: P, f: F) -> Result<R>
 where
     P: AsRef<Path>,

--- a/tests/snapshots/integration__create_with_name.snap
+++ b/tests/snapshots/integration__create_with_name.snap
@@ -2,6 +2,6 @@
 source: tests/integration.rs
 expression: redacted
 ---
-✨ Creating worktree 'feature-x'...
+✨ Creating worktree 'feature-x' with branch 'feature-x'...
 ✅ Worktree created at: /tmp/TEST_DIR/test-repo-feature-x
   💡 To open it, run: xlaude open feature-x

--- a/tests/snapshots/integration__create_with_slash_in_branch_name.snap
+++ b/tests/snapshots/integration__create_with_slash_in_branch_name.snap
@@ -1,0 +1,7 @@
+---
+source: tests/integration.rs
+expression: redacted
+---
+✨ Creating worktree 'fix-bug' with branch 'fix/bug'...
+✅ Worktree created at: /tmp/TEST_DIR/test-repo-fix-bug
+  💡 To open it, run: xlaude open fix-bug

--- a/tests/snapshots/integration__create_with_submodules.snap
+++ b/tests/snapshots/integration__create_with_submodules.snap
@@ -2,7 +2,7 @@
 source: tests/integration.rs
 expression: redacted
 ---
-✨ Creating worktree 'with-submodule'...
+✨ Creating worktree 'with-submodule' with branch 'with-submodule'...
 📦 Updated submodules
 ✅ Worktree created at: /tmp/TEST_DIR/test-repo-with-submodule
   💡 To open it, run: xlaude open with-submodule

--- a/tests/snapshots/integration__create_without_submodules.snap
+++ b/tests/snapshots/integration__create_without_submodules.snap
@@ -2,6 +2,6 @@
 source: tests/integration.rs
 expression: redacted
 ---
-✨ Creating worktree 'no-submodule'...
+✨ Creating worktree 'no-submodule' with branch 'no-submodule'...
 ✅ Worktree created at: /tmp/TEST_DIR/test-repo-no-submodule
   💡 To open it, run: xlaude open no-submodule


### PR DESCRIPTION
## Summary
- Fixes #32 
- Branch names containing slashes (e.g., `fix/bug`, `feature/awesome`) now create worktrees with sanitized directory names

## Problem
When using `xlaude create` with branch names containing slashes, the tool was creating incorrect directory structures (e.g., `../repo-fix/bug` instead of `../repo-fix-bug`), causing `xlaude delete` to fail.

## Solution
- Added `sanitize_branch_name` utility function that replaces forward slashes with hyphens
- Updated `create`, `add`, and `open` commands to use sanitized names for directory paths
- Original branch names are preserved in Git, only directory names are sanitized
- Added comprehensive tests for slash handling

## Test Plan
- [x] Added `test_create_with_slash_in_branch_name` test
- [x] Added `test_delete_with_slash_in_branch_name` test
- [x] All existing tests pass
- [x] Manual testing with branch names like `fix/bug` and `feature/awesome`

## Example
```bash
# Before (would fail)
xlaude create fix/bug  # Creates ../repo-fix/bug (subdirectory)
cd ../repo-fix/bug
xlaude delete  # ERROR: Cannot find worktree

# After (works correctly)  
xlaude create fix/bug  # Creates ../repo-fix-bug (flat directory)
cd ../repo-fix-bug
xlaude delete  # SUCCESS: Worktree deleted
```

🤖 Generated with [Claude Code](https://claude.ai/code)