### PR TITLE
feat: add --type-text option with pipe input support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,8 @@ xlaude 是一个用于管理 Claude 实例的命令行工具，通过 git worktr
 - 切换到 worktree 目录
 - 启动 `claude --dangerously-skip-permissions`
 - 继承所有环境变量
+- 支持 `--type-text` 选项：在 Claude 启动后自动输入指定文本
+- 支持管道输入：使用 `--type-text` 不带参数时从管道读取文本，或将管道内容附加到指定文本后
 
 ### xlaude delete [name]
 删除 worktree 并清理：
@@ -92,6 +94,19 @@ xlaude create  # 可能创建 ../opendal-dolphin 目录
 # 打开并启动 Claude
 xlaude open feature-x  # 打开指定的 worktree
 xlaude open  # 如果在 worktree 中直接打开，否则交互式选择
+
+# 启动 Claude 并自动输入文本
+xlaude open --type-text "帮我调试这个问题"
+xlaude open feature-x --type-text "请帮我审查代码"
+
+# 通过管道传递文本给 Claude（需要使用 --type-text 标志）
+echo "帮我分析这个错误日志" | xlaude open --type-text
+cat error.log | xlaude open feature-x --type-text
+git diff | xlaude open --type-text  # 从管道读取 diff 输出
+
+# 将管道内容附加到指定文本后
+git diff | xlaude open --type-text "请分析这些代码变更："
+echo "具体错误信息" | xlaude open --type-text "帮我调试这个问题："
 
 # 将已存在的 worktree 添加到管理
 cd ../opendal-bugfix

--- a/README.md
+++ b/README.md
@@ -53,9 +53,26 @@ xlaude open
 
 # Interactive selection (when not in a worktree)
 xlaude open
+
+# Open and automatically send prompts to Claude and execute them
+xlaude open --type-text "Help me debug this issue"
+xlaude open feature-auth -t "Review my code changes"
+
+# Pipe content directly to Claude as prompts and execute them
+git diff | xlaude open --type-text
+cat error.log | xlaude open feature-debug -t
+
+# Combine CLI text with piped content as prompts and execute them
+git diff | xlaude open -t "Please analyze these changes:"
+cat error.log | xlaude open --type-text "Help debug this error:"
 ```
 
-This switches to the worktree directory and launches Claude with `--dangerously-skip-permissions`. When run without arguments in a worktree directory, it opens the current worktree directly.
+This switches to the worktree directory and launches Claude with `--dangerously-skip-permissions`. When run without arguments in a worktree directory, it opens the current worktree directly. 
+
+The `--type-text` (or `-t`) option allows you to automatically send prompts to Claude and execute them:
+- **With text**: `--type-text "your message"` or `-t "your message"` sends and executes the specified prompt
+- **Pipe only**: `--type-text` or `-t` (no argument) sends and executes piped input as a prompt
+- **Combined**: `--type-text "prefix"` or `-t "prefix"` with piped input sends and executes both the prefix text and piped content as a single prompt
 
 ### Add existing worktree
 
@@ -122,7 +139,19 @@ Renames a worktree in xlaude management. This only updates the xlaude state and 
 
 2. **Work on the feature** with Claude assistance
 
-3. **Switch contexts**:
+3. **Debug with context**:
+   ```bash
+   # Send error logs directly to Claude and get immediate analysis
+   npm test 2>&1 | xlaude open -t "Tests are failing:"
+   
+   # Get help with specific changes and immediate feedback
+   git diff HEAD~1 | xlaude open -t "Review this commit:"
+   
+   # Analyze code files and get optimization suggestions
+   cat src/auth.rs | xlaude open -t "Please help optimize this code:"
+   ```
+
+4. **Switch contexts**:
    ```bash
    xlaude open  # Select another workspace
    # Or if you're already in a worktree directory:
@@ -130,7 +159,7 @@ Renames a worktree in xlaude management. This only updates the xlaude state and 
    xlaude open  # Opens current worktree directly
    ```
 
-4. **Clean up** when done:
+5. **Clean up** when done:
    ```bash
    xlaude delete auth-system
    # Or clean up all invalid worktrees:

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,12 +4,14 @@ use clap::{Parser, Subcommand};
 mod claude;
 mod commands;
 mod git;
+mod options;
 mod state;
 mod utils;
 
 use commands::{
     handle_add, handle_clean, handle_create, handle_delete, handle_list, handle_open, handle_rename,
 };
+use options::OpenOptions;
 
 #[derive(Parser)]
 #[command(name = "xlaude")]
@@ -30,6 +32,8 @@ enum Commands {
     Open {
         /// Name of the worktree to open (interactive selection if not provided)
         name: Option<String>,
+        #[command(flatten)]
+        options: OpenOptions,
     },
     /// Delete a worktree and clean up
     Delete {
@@ -59,7 +63,7 @@ fn main() -> Result<()> {
 
     match cli.command {
         Commands::Create { name } => handle_create(name),
-        Commands::Open { name } => handle_open(name),
+        Commands::Open { name, options } => handle_open(name, options),
         Commands::Delete { name } => handle_delete(name),
         Commands::Add { name } => handle_add(name),
         Commands::Rename { old_name, new_name } => handle_rename(old_name, new_name),

--- a/src/options.rs
+++ b/src/options.rs
@@ -1,0 +1,49 @@
+use anyhow::Result;
+use clap::Args;
+use std::io::{self, IsTerminal, Read};
+
+#[derive(Args, Debug, Clone)]
+pub struct OpenOptions {
+    /// Prompt to send to Claude and execute after it starts (reads from stdin if no value provided, or appends stdin to provided text)
+    #[arg(short = 't', long, value_name = "TEXT")]
+    pub type_text: Option<Option<String>>,
+}
+
+impl OpenOptions {
+    /// Get the text to type, either from CLI argument or stdin
+    pub fn get_type_text(&self) -> Result<Option<String>> {
+        match &self.type_text {
+            Some(Some(text)) => {
+                // --type-text "some text" was provided
+                // Check if there's also piped input to append
+                if !io::stdin().is_terminal() {
+                    let mut buffer = String::new();
+                    io::stdin().read_to_string(&mut buffer)?;
+
+                    if buffer.trim().is_empty() {
+                        Ok(Some(text.clone()))
+                    } else {
+                        Ok(Some(format!("{}\n{}", text, buffer.trim_end())))
+                    }
+                } else {
+                    Ok(Some(text.clone()))
+                }
+            }
+            Some(None) => {
+                // --type-text was provided without value, read from stdin
+                let mut buffer = String::new();
+                io::stdin().read_to_string(&mut buffer)?;
+
+                if buffer.trim().is_empty() {
+                    Ok(None)
+                } else {
+                    Ok(Some(buffer.trim_end().to_string()))
+                }
+            }
+            None => {
+                // --type-text was not provided
+                Ok(None)
+            }
+        }
+    }
+}

--- a/tests/snapshots/integration__open_test_mode_without_type_text.snap
+++ b/tests/snapshots/integration__open_test_mode_without_type_text.snap
@@ -1,0 +1,5 @@
+---
+source: tests/integration.rs
+expression: redacted
+---
+🚀 Opening worktree 'test-repo/test-no-text'...

--- a/tests/snapshots/integration__open_type_text_value_appends_pipe.snap
+++ b/tests/snapshots/integration__open_type_text_value_appends_pipe.snap
@@ -1,0 +1,8 @@
+---
+source: tests/integration.rs
+expression: redacted
+---
+🚀 Opening worktree 'test-repo/test-append'...
+[TEST MODE] Simulating prompt execution in Claude Code:
+CLI argument
+Piped input to append

--- a/tests/snapshots/integration__open_with_pipe_input.snap
+++ b/tests/snapshots/integration__open_with_pipe_input.snap
@@ -1,0 +1,8 @@
+---
+source: tests/integration.rs
+expression: redacted
+---
+🚀 Opening worktree 'test-repo/test-pipe'...
+[TEST MODE] Simulating prompt execution in Claude Code:
+Hello from pipe!
+This is multi-line input.

--- a/tests/snapshots/integration__open_with_type_text.snap
+++ b/tests/snapshots/integration__open_with_type_text.snap
@@ -1,0 +1,7 @@
+---
+source: tests/integration.rs
+expression: redacted
+---
+🚀 Opening worktree 'test-repo/test-typing'...
+[TEST MODE] Simulating prompt execution in Claude Code:
+Hello Claude!


### PR DESCRIPTION
## Summary
Add a new `--type-text` option to the `open` command that allows automatically typing text into Claude Code upon launch, with full pipe input support for seamless workflow integration.

## Key Features
- **CLI text input**: `xlaude open --type-text "your message"`
- **Pipe input support**: `git diff | xlaude open --type-text`
- **Combined usage**: `git diff | xlaude open --type-text "Please review:"`
- **Test mode improvements**: Clear test indicators for better debugging

## Implementation Details
- Extract `OpenOptions` struct for better command organization
- Add comprehensive pipe input handling with proper error management
- Implement test mode with clear indicators (`[TEST MODE] Simulating type input to Claude Code:`)
- Add extensive test coverage with snapshot testing
- Enhanced documentation with practical examples

## Use Cases
```bash
# Debug failing tests
npm test 2>&1 | xlaude open --type-text "Tests are failing:"

# Code review assistance  
git diff HEAD~1 | xlaude open --type-text "Please review this commit:"

# File analysis
cat src/auth.rs | xlaude open --type-text "Help optimize this code:"
```

## Test Coverage
- Comprehensive integration tests with snapshot verification
- Test mode simulation for CI/CD environments
- Error handling for pipe failures
- Multi-line input support

🤖 Generated with [Claude Code](https://claude.ai/code)