### PR TITLE
fix: Prevent creating worktrees with existing names

### DIFF
--- a/src/commands/create.rs
+++ b/src/commands/create.rs
@@ -5,7 +5,7 @@ use std::fs;
 use std::path::PathBuf;
 
 use crate::commands::open::handle_open;
-use crate::git::{execute_git, extract_repo_name_from_url, get_repo_name, update_submodules};
+use crate::git::{execute_git, extract_repo_name_from_url, get_repo_name, list_worktrees, update_submodules};
 use crate::input::{get_command_arg, smart_confirm};
 use crate::state::{WorktreeInfo, XlaudeState};
 use crate::utils::{generate_random_name, sanitize_branch_name};
@@ -81,6 +81,60 @@ pub fn handle_create_in_dir_quiet(
 
     // Sanitize the branch name for use in directory names
     let worktree_name = sanitize_branch_name(&branch_name);
+
+    // Check if a worktree with this name already exists in xlaude state
+    let state = XlaudeState::load()?;
+    let key = XlaudeState::make_key(&repo_name, &worktree_name);
+    if state.worktrees.contains_key(&key) {
+        anyhow::bail!(
+            "A worktree named '{}' already exists for repository '{}' (tracked by xlaude). Please choose a different name.",
+            worktree_name,
+            repo_name
+        );
+    }
+    
+    // Check if the worktree directory will be created
+    let worktree_dir_path = if let Some(ref path) = repo_path {
+        path.parent()
+            .unwrap()
+            .join(format!("{repo_name}-{worktree_name}"))
+    } else {
+        std::env::current_dir()?
+            .parent()
+            .unwrap()
+            .join(format!("{repo_name}-{worktree_name}"))
+    };
+    
+    // Check if the directory already exists
+    if worktree_dir_path.exists() {
+        anyhow::bail!(
+            "Directory '{}' already exists. Please choose a different name or remove the existing directory.",
+            worktree_dir_path.display()
+        );
+    }
+    
+    // Check if a git worktree already exists at this path
+    // Need to run git worktree list in the correct directory
+    let existing_worktrees = if let Some(ref path) = repo_path {
+        // Parse git worktree list output from the specified directory
+        let output = execute_git(&["-C", path.to_str().unwrap(), "worktree", "list", "--porcelain"])?;
+        let mut worktrees = Vec::new();
+        for line in output.lines() {
+            if let Some(worktree_path) = line.strip_prefix("worktree ") {
+                worktrees.push(PathBuf::from(worktree_path));
+            }
+        }
+        worktrees
+    } else {
+        list_worktrees()?
+    };
+    
+    if existing_worktrees.iter().any(|w| w == &worktree_dir_path) {
+        anyhow::bail!(
+            "A git worktree already exists at '{}'. Please choose a different name or remove the existing worktree.",
+            worktree_dir_path.display()
+        );
+    }
 
     // Check if the branch already exists
     let branch_already_exists = exec_git(&[

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -718,6 +718,80 @@ fn test_rename_command() {
 }
 
 #[test]
+fn test_create_duplicate_name() {
+    let ctx = TestContext::new("test-repo");
+
+    // Create a worktree with a specific name
+    ctx.xlaude(&["create", "my-feature"]).assert().success();
+
+    // Try to create another worktree with the same name - should fail
+    ctx.xlaude(&["create", "my-feature"])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("already exists"))
+        .stderr(predicates::str::contains("my-feature"));
+
+    // Verify only one worktree exists in the state
+    let state = ctx.read_state();
+    if let Some(worktrees) = state["worktrees"].as_object() {
+        assert_eq!(worktrees.len(), 1, "Should have exactly one worktree");
+    }
+}
+
+#[test]
+fn test_create_existing_git_worktree() {
+    let ctx = TestContext::new("test-repo");
+    
+    // Create a worktree manually using git (not tracked by xlaude)
+    std::process::Command::new("git")
+        .args([
+            "worktree",
+            "add",
+            "-b",
+            "existing-feature",
+            "../test-repo-existing-feature",
+        ])
+        .current_dir(&ctx.repo_dir)
+        .output()
+        .unwrap();
+    
+    // Try to create a worktree with the same name through xlaude - should fail
+    ctx.xlaude(&["create", "existing-feature"])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("already exists"));
+    
+    // Verify xlaude state is still empty
+    let state = ctx.read_state();
+    if let Some(worktrees) = state["worktrees"].as_object() {
+        assert_eq!(worktrees.len(), 0, "Should have no worktrees in xlaude state");
+    }
+}
+
+#[test]
+fn test_create_existing_directory() {
+    let ctx = TestContext::new("test-repo");
+    
+    // Create a directory manually (not a git worktree)
+    let existing_dir = ctx.temp_dir.path().join("test-repo-existing-dir");
+    fs::create_dir(&existing_dir).unwrap();
+    fs::write(existing_dir.join("file.txt"), "existing content").unwrap();
+    
+    // Try to create a worktree with the same name - should fail
+    ctx.xlaude(&["create", "existing-dir"])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("Directory"))
+        .stderr(predicates::str::contains("already exists"));
+    
+    // Verify xlaude state is still empty
+    let state = ctx.read_state();
+    if let Some(worktrees) = state["worktrees"].as_object() {
+        assert_eq!(worktrees.len(), 0, "Should have no worktrees in xlaude state");
+    }
+}
+
+#[test]
 fn test_create_with_submodules() {
     let ctx = TestContext::new("test-repo");
 


### PR DESCRIPTION
## Summary
- Fixes #49 - xlaude create allows creating worktree with existing name not tracked by xlaude
- Adds comprehensive validation before attempting to create worktrees
- Includes tests for all edge cases

## Changes
- Added validation to check if directory already exists on disk before creating worktree
- Added validation to check if git worktree already exists at the target path
- Updated error messages to be more specific about the conflict type
- Added integration tests for both scenarios

## Test Plan
- [x] Added `test_create_existing_git_worktree` - verifies xlaude properly detects existing git worktrees
- [x] Added `test_create_existing_directory` - verifies xlaude properly detects existing directories
- [x] All existing tests pass
- [x] Manual testing confirms the fix works as expected

🤖 Generated with [Claude Code](https://claude.ai/code)