### PR TITLE
feat: Add dashboard command to shell completions

### DIFF
--- a/src/completions.rs
+++ b/src/completions.rs
@@ -32,7 +32,7 @@ _xlaude() {{
     fi
 
     # Main commands
-    local commands="create open delete add rename list clean dir completions"
+    local commands="create open delete add rename list clean dir dashboard completions"
 
     # Complete main commands
     if [[ $cword -eq 1 ]]; then
@@ -84,6 +84,7 @@ _xlaude() {{
         'list:List all active Claude instances'
         'clean:Clean up invalid worktrees from state'
         'dir:Get the directory path of a worktree'
+        'dashboard:Launch interactive dashboard for managing Claude sessions'
         'completions:Generate shell completions'
     )
 
@@ -177,6 +178,7 @@ complete -c xlaude -n "__fish_use_subcommand" -a rename -d "Rename a worktree"
 complete -c xlaude -n "__fish_use_subcommand" -a list -d "List all active Claude instances"
 complete -c xlaude -n "__fish_use_subcommand" -a clean -d "Clean up invalid worktrees from state"
 complete -c xlaude -n "__fish_use_subcommand" -a dir -d "Get the directory path of a worktree"
+complete -c xlaude -n "__fish_use_subcommand" -a dashboard -d "Launch interactive dashboard for managing Claude sessions"
 complete -c xlaude -n "__fish_use_subcommand" -a completions -d "Generate shell completions"
 
 # Function to get worktree completions with repo markers


### PR DESCRIPTION
## Summary
- Added `dashboard` command to bash, zsh, and fish shell completions

## Test plan
- [x] Tested bash completions: `cargo run -- completions bash | grep dashboard`
- [x] Tested zsh completions: `cargo run -- completions zsh | grep dashboard`  
- [x] Tested fish completions: `cargo run -- completions fish | grep dashboard`
- [x] All tests pass: `cargo test`

Fixes #55

🤖 Generated with [Claude Code](https://claude.ai/code)