### PR TITLE
fix: duplicate input characters in dashboard create mode

### DIFF
--- a/src/commands/dashboard.rs
+++ b/src/commands/dashboard.rs
@@ -38,6 +38,7 @@ pub struct Dashboard {
     claude_statuses: std::collections::HashMap<String, ClaudeStatus>,
     config_mode: bool,
     config_editor_input: String,
+    last_key_event: Option<(KeyEvent, std::time::Instant)>, // Track last key event for deduplication
 }
 
 struct WorktreeDisplay {
@@ -73,6 +74,7 @@ impl Dashboard {
             claude_statuses: std::collections::HashMap::new(),
             config_mode: false,
             config_editor_input: String::new(),
+            last_key_event: None,
         };
 
         dashboard.refresh_worktrees();
@@ -251,6 +253,11 @@ impl Dashboard {
                             execute!(terminal.backend_mut(), EnterAlternateScreen)?;
                             terminal.hide_cursor()?;
 
+                            // Clear event queue to prevent duplicate input after terminal mode switch
+                            while event::poll(Duration::from_millis(0))? {
+                                let _ = event::read()?;
+                            }
+
                             // Force clear and redraw
                             terminal.clear()?;
 
@@ -333,6 +340,20 @@ impl Dashboard {
     }
 
     fn handle_input(&mut self, key: KeyEvent) -> Result<InputResult> {
+        // Check for duplicate key events within a short time window (50ms)
+        let now = std::time::Instant::now();
+        if let Some((last_key, last_time)) = &self.last_key_event {
+            if key.code == last_key.code 
+                && key.modifiers == last_key.modifiers 
+                && now.duration_since(*last_time).as_millis() < 50 
+            {
+                // This is likely a duplicate event, ignore it
+                return Ok(InputResult::Continue);
+            }
+        }
+        
+        // Update last key event
+        self.last_key_event = Some((key, now));
         if self.show_help {
             self.show_help = false;
             return Ok(InputResult::Continue);


### PR DESCRIPTION
Added input deduplication mechanism to prevent character duplication during worktree name input in dashboard create mode.

Changes:
- Added last_key_event tracking with 50ms time window
- Implemented duplicate event detection in handle_input method
- Simple and efficient solution that preserves input responsiveness

🤖 Generated with [Claude Code](https://claude.ai/code)