### PR TITLE
fix: display worktree creation time in local timezone

### DIFF
--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -162,7 +162,7 @@ pub fn handle_list(json: bool) -> Result<()> {
                     "Created:".bright_black(),
                     info.created_at
                         .with_timezone(&Local)
-                        .format("%Y-%m-%d %H:%M:%S %Z")
+                        .format("%Y-%m-%d %H:%M:%S")
                 );
 
                 // Get Claude sessions for this worktree

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,4 +1,5 @@
 use assert_cmd::Command;
+use assert_cmd::cargo::cargo_bin_cmd;
 use insta::{assert_json_snapshot, assert_snapshot};
 use regex::Regex;
 use serde_json::json;
@@ -88,7 +89,7 @@ impl TestContext {
     }
 
     fn xlaude(&self, args: &[&str]) -> Command {
-        let mut cmd = Command::cargo_bin("xlaude").unwrap();
+        let mut cmd = cargo_bin_cmd!("xlaude");
         cmd.current_dir(&self.repo_dir)
             .env("HOME", self.temp_dir.path())
             .env("XLAUDE_CONFIG_DIR", &self.config_dir)
@@ -104,7 +105,7 @@ impl TestContext {
     }
 
     fn xlaude_in_dir(&self, dir: &Path, args: &[&str]) -> Command {
-        let mut cmd = Command::cargo_bin("xlaude").unwrap();
+        let mut cmd = cargo_bin_cmd!("xlaude");
         cmd.current_dir(dir)
             .env("HOME", self.temp_dir.path())
             .env("XLAUDE_CONFIG_DIR", &self.config_dir)
@@ -712,7 +713,7 @@ fn test_open_from_non_git_directory() {
     fs::write(config_dir.join("state.json"), state.to_string()).unwrap();
 
     // Try to open from a non-git directory with empty worktrees
-    let mut cmd = Command::cargo_bin("xlaude").unwrap();
+    let mut cmd = cargo_bin_cmd!("xlaude");
     cmd.current_dir(&non_git_dir)
         .env("HOME", temp_dir.path())
         .env("XLAUDE_CONFIG_DIR", &config_dir)

--- a/tests/test_dashboard.rs
+++ b/tests/test_dashboard.rs
@@ -1,13 +1,13 @@
 #[cfg(test)]
 mod dashboard_tests {
-    use assert_cmd::Command;
+    use assert_cmd::cargo::cargo_bin_cmd;
     use predicates::prelude::*;
 
     #[test]
     fn test_dashboard_without_tmux() {
         // If tmux is not available, should show helpful error
         if !tmux_available() {
-            let mut cmd = Command::cargo_bin("xlaude").unwrap();
+            let mut cmd = cargo_bin_cmd!("xlaude");
             cmd.arg("dashboard");
 
             cmd.assert()
@@ -18,7 +18,7 @@ mod dashboard_tests {
 
     #[test]
     fn test_dashboard_help() {
-        let mut cmd = Command::cargo_bin("xlaude").unwrap();
+        let mut cmd = cargo_bin_cmd!("xlaude");
         cmd.arg("dashboard").arg("--help");
 
         cmd.assert()


### PR DESCRIPTION
- Convert UTC timestamps to local timezone in list command output
- Improves user experience by showing times in user's local timezone
- Fixes issue where UTC times were displayed without timezone context

Previously: 2025-10-31 06:36:33 (UTC)
Now: 2025-10-31 14:36:33 (local timezone)

<img width="428" height="144" alt="image" src="https://github.com/user-attachments/assets/efb7111c-148a-43ae-ae36-637ff3622de0" />

for pass ci migrate to assert_cmd v2 API